### PR TITLE
ArabicShaping: Initialize member variables in declaration order

### DIFF
--- a/Tools/Parser/ArabicShaping.cpp
+++ b/Tools/Parser/ArabicShaping.cpp
@@ -33,10 +33,10 @@ static inline string getField(const string &data, size_t offset) {
 }
 
 ArabicShaping::ArabicShaping(const string &directory) :
-    m_data(""),
-    m_offsets(0x200000),
     m_firstCodePoint(0),
-    m_lastCodePoint(0)
+    m_lastCodePoint(0),
+    m_data(""),
+    m_offsets(0x200000)
 {
     ifstream stream(directory + "/" + FILE_ARABIC_SHAPING, ios::binary);
     char buffer[4096];


### PR DESCRIPTION
This fixes the following warning when compiling with Apple clang 15.0.0:

```
Compiling C++ object libparser.dylib.p/Tools_Parser_ArabicShaping.cpp.o
../Tools/Parser/ArabicShaping.cpp:37:5: warning: field 'm_offsets' will be initialized after field 'm_firstCodePoint' [-Wreorder-ctor]
    m_offsets(0x200000),
    ^~~~~~~~~~~~~~~~~~~
    m_lastCodePoint(0)
1 warning generated.
```