### PR TITLE
In Tester, add virtual destructor to Table class

### DIFF
--- a/Tools/Tester/OpenType/Base.h
+++ b/Tools/Tester/OpenType/Base.h
@@ -42,6 +42,7 @@ inline F2DOT14 toF2DOT14(float value) {
 }
 
 struct Table {
+    virtual ~Table() {}
     virtual void write(Writer &writer) = 0;
 };
 


### PR DESCRIPTION
This fixes 74 C++ compiler warnings when building SheenFigure with Apple clang 15.0.0. For example, after this change, the following warning does not get emitted anymore:

```
Compiling C++ object sheenfigure_tester.p/Tools_Tester_MiscTester.cpp.o
In file included from ../Tools/Tester/MiscTester.cpp:19:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/vector:290:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__bit_reference:20:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/construct_at.h:66:5: warning: destructor called on non-final 'SheenFigure::Tester::OpenType::ItemVariationDataSubtable' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
    __loc->~_Tp();
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/construct_at.h:101:12: note: in instantiation of function template specialization 'std::__destroy_at<SheenFigure::Tester::OpenType::ItemVariationDataSubtable, 0>' requested here
    _VSTD::__destroy_at(__loc);
           ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/allocator_traits.h:323:16: note: in instantiation of function template specialization 'std::destroy_at<SheenFigure::Tester::OpenType::ItemVariationDataSubtable, 0>' requested here
        _VSTD::destroy_at(__p);
               ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/vector:836:25: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<SheenFigure::Tester::OpenType::ItemVariationDataSubtable>>::destroy<SheenFigure::Tester::OpenType::ItemVariationDataSubtable, void, void>' requested here
        __alloc_traits::destroy(__alloc(), std::__to_address(--__soon_to_be_end));
                        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/vector:830:29: note: in instantiation of member function 'std::vector<SheenFigure::Tester::OpenType::ItemVariationDataSubtable>::__base_destruct_at_end' requested here
  void __clear() _NOEXCEPT {__base_destruct_at_end(this->__begin_);}
                            ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/vector:446:20: note: in instantiation of member function 'std::vector<SheenFigure::Tester::OpenType::ItemVariationDataSubtable>::__clear' requested here
            __vec_.__clear();
                   ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__utility/exception_guard.h:84:7: note: in instantiation of member function 'std::vector<SheenFigure::Tester::OpenType::ItemVariationDataSubtable>::__destroy_vector::operator()' requested here
      __rollback_();
      ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__utility/exception_guard.h:134:10: note: in instantiation of member function 'std::__exception_guard_exceptions<std::vector<SheenFigure::Tester::OpenType::ItemVariationDataSubtable>::__destroy_vector>::~__exception_guard_exceptions' requested here
  return __exception_guard<_Rollback>(std::move(__rollback));
         ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/vector:1265:25: note: in instantiation of function template specialization 'std::__make_exception_guard<std::vector<SheenFigure::Tester::OpenType::ItemVariationDataSubtable>::__destroy_vector>' requested here
    auto __guard = std::__make_exception_guard(__destroy_vector(*this));
                        ^
../Tools/Tester/MiscTester.cpp:156:49: note: in instantiation of member function 'std::vector<SheenFigure::Tester::OpenType::ItemVariationDataSubtable>::vector' requested here
    vector<ItemVariationDataSubtable> varData = {
                                                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/construct_at.h:66:13: note: qualify call to silence this warning
    __loc->~_Tp();
            ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/construct_at.h:66:5: warning: destructor called on non-final 'SheenFigure::Tester::OpenType::ConditionTable' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
    __loc->~_Tp();
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/construct_at.h:101:12: note: in instantiation of function template specialization 'std::__destroy_at<SheenFigure::Tester::OpenType::ConditionTable, 0>' requested here
    _VSTD::__destroy_at(__loc);
           ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/allocator_traits.h:323:16: note: in instantiation of function template specialization 'std::destroy_at<SheenFigure::Tester::OpenType::ConditionTable, 0>' requested here
        _VSTD::destroy_at(__p);
               ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/vector:836:25: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<SheenFigure::Tester::OpenType::ConditionTable>>::destroy<SheenFigure::Tester::OpenType::ConditionTable, void, void>' requested here
        __alloc_traits::destroy(__alloc(), std::__to_address(--__soon_to_be_end));
                        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/vector:830:29: note: in instantiation of member function 'std::vector<SheenFigure::Tester::OpenType::ConditionTable>::__base_destruct_at_end' requested here
  void __clear() _NOEXCEPT {__base_destruct_at_end(this->__begin_);}
                            ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/vector:446:20: note: in instantiation of member function 'std::vector<SheenFigure::Tester::OpenType::ConditionTable>::__clear' requested here
            __vec_.__clear();
                   ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__utility/exception_guard.h:84:7: note: in instantiation of member function 'std::vector<SheenFigure::Tester::OpenType::ConditionTable>::__destroy_vector::operator()' requested here
      __rollback_();
      ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__utility/exception_guard.h:134:10: note: in instantiation of member function 'std::__exception_guard_exceptions<std::vector<SheenFigure::Tester::OpenType::ConditionTable>::__destroy_vector>::~__exception_guard_exceptions' requested here
  return __exception_guard<_Rollback>(std::move(__rollback));
         ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/vector:1265:25: note: in instantiation of function template specialization 'std::__make_exception_guard<std::vector<SheenFigure::Tester::OpenType::ConditionTable>::__destroy_vector>' requested here
    auto __guard = std::__make_exception_guard(__destroy_vector(*this));
                        ^
../Tools/Tester/MiscTester.cpp:209:41: note: in instantiation of member function 'std::vector<SheenFigure::Tester::OpenType::ConditionTable>::vector' requested here
    vector<ConditionTable> conditions = {
                                        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/construct_at.h:66:13: note: qualify call to silence this warning
    __loc->~_Tp();
            ^
```