### PR TITLE
In Tester, fix C++ compiler warning with Apple clang 15.0

### DIFF
--- a/Tools/Tester/OpenType/Builder.cpp
+++ b/Tools/Tester/OpenType/Builder.cpp
@@ -44,7 +44,10 @@ Builder::~Builder()
 template<class T, class... Args>
 T &Builder::createObject(Args&&... args)
 {
-    shared_ptr<T> object = make_shared<T>(forward<Args>(args)...);
+    // Apple C++ clang 15.0 emits compiler warnings if std::forward
+    // is not explicitly qualified with the namespace, despite
+    // "using namespace std" earlier in this file.
+    shared_ptr<T> object = make_shared<T>(std::forward<Args>(args)...);
     m_pool.push_back(object);
 
     return *object;


### PR DESCRIPTION
This fixes 39 C++ compiler warnings when building SheenFigure with Apple clang 15.0.0. For example, after this change, the following warning does not get emitted anymore:

```
Compiling C++ object sheenfigure_tester.p/Tools_Tester_OpenType_Builder.cpp.o
../Tools/Tester/OpenType/Builder.cpp:47:43: warning: unqualified call to 'std::forward' [-Wunqualified-std-cast-call]
    shared_ptr<T> object = make_shared<T>(forward<Args>(args)...);
                                          ^
                                          std::
../Tools/Tester/OpenType/Builder.cpp:56:36: note: in instantiation of function template specialization 'SheenFigure::Tester::OpenType::Builder::createObject<std::vector<unsigned short>, unsigned long &>' requested here
    return (size == 0 ? nullptr : &createObject<vector<T>>(size)[0]);
                                   ^                              ^
```